### PR TITLE
Add flag to concat string on mergeAttributes

### DIFF
--- a/lib/mixins/helpers.coffee
+++ b/lib/mixins/helpers.coffee
@@ -65,7 +65,7 @@ module.exports = ($) ->
   $.getAttribute = (node,key) ->
     node?.attributes?[key]
 
-  $.mergeAttributes = (attributes1={},attributes2={},exclusions=[]) ->
+  $.mergeAttributes = (attributes1={},attributes2={},exclusions=[],concatString=false) ->
     # merge shared key values where value is same type, preferring attributes1, otherwise fallback to attributes2
     attributes = {}
     for key, val of attributes1
@@ -76,10 +76,8 @@ module.exports = ($) ->
         if (v1 instanceof Array) and (v2 instanceof Array)
           attributes[key] = v1.concat v2
         else if (typeof v1 is 'string') and (typeof v2 is 'string')
-          if v1 isnt v2
-            attributes[key] += v1 + " " + v2
-          else
-            attributes[key] = v1
+          if v1 isnt v2 and concatString
+            attributes[key] += " " + v2
         else if (typeof v1 is 'object') and (typeof v2 is 'object')
           # TODO: not clone
           # clone to not disrupt $h!t up the closures

--- a/spec/helpers.coffee
+++ b/spec/helpers.coffee
@@ -119,6 +119,20 @@ describe "Helpers", ->
     mergedAttrs = $.mergeAttributes attrs, attrs1, ['data']
     expect(mergedAttrs).to.deep.equal {class: ['hello', 'world'], index: 'super' }
 
+  it 'merge with concat string', ->
+    attrs = {str: 'first' }
+    attrs1 = {str: 'second' }
+
+    mergedAttrs = $.mergeAttributes attrs, attrs1, [], true
+    expect(mergedAttrs).to.deep.equal {str: 'first second' }
+
+  it 'merge without concat string', ->
+    attrs = {str: 'first' }
+    attrs1 = {str: 'second' }
+
+    mergedAttrs = $.mergeAttributes attrs, attrs1, [], false
+    expect(mergedAttrs).to.deep.equal {str: 'first' }
+
 
   describe 'get & set Attribute', ->
 


### PR DESCRIPTION
String concatenation seems to be a edge case regarding GOM. So I added a flag to concat only if set to true.

Otherwise, the first object property will have precedence over the second. 
