### PR TITLE
Add default value for attributes.

### DIFF
--- a/lib/GOM.coffee
+++ b/lib/GOM.coffee
@@ -12,7 +12,7 @@
 
 module.exports = (hooks={}) ->
 
-  $ = (tag, attributes, children, rest...) ->
+  $ = (tag, attributes = {}, children, rest...) ->
     hook = hooks[tag]
     return hook.apply $, [attributes, children, rest...] if hook
     return new Node tag, attributes, children

--- a/spec/GOM.coffee
+++ b/spec/GOM.coffee
@@ -220,3 +220,8 @@ describe "GOM", ->
         """
           <div id="styled" style="background-color:blue; color:hsl(0,0%,0%); line-height:1.5;"></div>
         """
+
+
+    it "default value for attributes", ->
+      node = $ "div", null, []
+      expect(node.attributes).to.deep.equal {}


### PR DESCRIPTION
This pull request should prevent having to check for the existence of `node.attributes` before accessing properties on it.

Currently this is necessary if `null` or `undefined` is passed as the second argument when creating a node.
