### PR TITLE
Fix coffeeify transform dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   ],
   "dependencies": {
     "coffee-script": "^1.8.0",
-    "clone": "^1.0.1"
+    "clone": "^1.0.1",
+    "coffeeify": "^1.0.0"
   },
   "devDependencies": {
     "chai": "~1.9.0",
     "grunt": "~0.4.1",
-    "coffeeify": "^1.0.0",
     "grunt-browserify": "^3.4.0",
     "grunt-cafe-mocha": "~0.1.12",
     "grunt-coffeelint": "~0.0.10",


### PR DESCRIPTION
This pull request fixes an issue where gom is a dependency but coffeeify is missing.

The browserify README [says the following](https://github.com/substack/node-browserify#browserifytransform) about specifying source transforms in the browserify.transform field of package.json:

> Make sure to add transforms to your package.json dependencies field.
